### PR TITLE
Remove unnecessary linkage against google benchmark and google test.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ enable_testing()
 
 # Find required packages
 find_package(OpenMP REQUIRED)
-find_package(GTest CONFIG REQUIRED)
-find_package(benchmark CONFIG REQUIRED)
+find_package(GTest REQUIRED)
+find_package(benchmark REQUIRED)
 
 # Base library
 add_library(matrix_lib INTERFACE)
@@ -28,8 +28,6 @@ target_include_directories(matrix_lib INTERFACE include)
 target_link_libraries(matrix_lib INTERFACE
     "-framework Accelerate"
     OpenMP::OpenMP_CXX
-    GTest::gtest
-    benchmark::benchmark
 )
 
 add_subdirectory(benchmark)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(
 target_link_libraries(
   matrix_test
   matrix_lib
+  GTest::gtest
   GTest::gtest_main
 )
 


### PR DESCRIPTION
# Fix CMake Configuration Issues

## Changes
- Remove `CONFIG` mode from `find_package` commands for GTest and benchmark to support multiple package discovery methods
- Remove test dependencies from `matrix_lib` interface to maintain proper separation of concerns

## Technical Details
- GTest and benchmark are now found using default CMake package discovery
- Testing libraries are no longer propagated to targets that link against `matrix_lib`
- Core library dependencies remain unchanged (Accelerate framework and OpenMP)